### PR TITLE
Place before namespace if no include found

### DIFF
--- a/plugin/cpp_auto_include.vim
+++ b/plugin/cpp_auto_include.vim
@@ -122,6 +122,8 @@ module CppAutoInclude
       VIM::lines.each_with_index do |l, i|
         if l =~ /^\s*#\s*include/
           includes << [l, i+1]
+        elsif l =~ /^\s*namespace/ and includes.length == 1
+          includes[0][-1] = i
         else
           content << l.gsub(/\/\/[^"]*(?:"[^"']*"[^"]*)*$/,'') << "\n"
         end


### PR DESCRIPTION
In case you use this in header files, it would be better to look for a
namespace declaration then putting it on top, where the guard header
should be.
